### PR TITLE
Add possibility to compile applications with address sanitizer. #2123

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -24,69 +24,69 @@ DBGFLAGS = -g
 endif
 
 vlanmgrd_SOURCES = vlanmgrd.cpp vlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vlanmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vlanmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 teammgrd_SOURCES = teammgrd.cpp teammgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-teammgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+teammgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 portmgrd_SOURCES = portmgrd.cpp portmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-portmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-portmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-portmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+portmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+portmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+portmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 intfmgrd_SOURCES = intfmgrd.cpp intfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/lib/subintf.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-intfmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+intfmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 buffermgrd_SOURCES = buffermgrd.cpp buffermgr.cpp buffermgrdyn.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-buffermgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-buffermgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-buffermgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+buffermgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+buffermgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+buffermgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 vrfmgrd_SOURCES = vrfmgrd.cpp vrfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vrfmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vrfmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 nbrmgrd_SOURCES = nbrmgrd.cpp nbrmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CFLAGS)
-nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CPPFLAGS)
-nbrmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS) $(LIBNL_LIBS)
+nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CFLAGS) $(CFLAGS_ASAN)
+nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CPPFLAGS) $(CFLAGS_ASAN)
+nbrmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS) $(LIBNL_LIBS)
 
 vxlanmgrd_SOURCES = vxlanmgrd.cpp vxlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vxlanmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vxlanmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 sflowmgrd_SOURCES = sflowmgrd.cpp sflowmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-sflowmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-sflowmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-sflowmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+sflowmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+sflowmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+sflowmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 natmgrd_SOURCES = natmgrd.cpp natmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-natmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-natmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-natmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+natmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+natmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+natmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 coppmgrd_SOURCES = coppmgrd.cpp coppmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-coppmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-coppmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-coppmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+coppmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+coppmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+coppmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 tunnelmgrd_SOURCES = tunnelmgrd.cpp tunnelmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-tunnelmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-tunnelmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-tunnelmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+tunnelmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+tunnelmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+tunnelmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 macsecmgrd_SOURCES = macsecmgrd.cpp macsecmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-macsecmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-macsecmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-macsecmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+macsecmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+macsecmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+macsecmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 if GCOV_ENABLED
 vlanmgrd_LDADD += -lgcovpreload

--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -1,6 +1,8 @@
 #include <unistd.h>
 #include <vector>
 #include <mutex>
+#include <signal.h>
+
 #include "dbconnector.h"
 #include "select.h"
 #include "exec.h"
@@ -9,6 +11,10 @@
 #include <fstream>
 #include <iostream>
 #include "warm_restart.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -36,12 +42,29 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("intfmgrd");
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("--- Starting intfmgrd ---");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     try
     {

--- a/cfgmgr/macsecmgrd.cpp
+++ b/cfgmgr/macsecmgrd.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <mutex>
 #include <algorithm>
+#include <signal.h>
 
 #include <logger.h>
 #include <producerstatetable.h>
@@ -16,6 +17,10 @@
 #include <select.h>
 
 #include "macsecmgr.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -45,9 +50,24 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
 
 int main(int argc, char **argv)
 {
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     try
     {

--- a/cfgmgr/natmgrd.cpp
+++ b/cfgmgr/natmgrd.cpp
@@ -33,6 +33,10 @@
 #include "shellcmd.h"
 #include "warm_restart.h"
 
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
+
 using namespace std;
 using namespace swss;
 
@@ -98,6 +102,12 @@ void sigterm_handler(int signo)
         natmgr->cleanupMangleIpTables();
         natmgr->cleanupPoolIpTable();
     }
+
+#if defined(ASAN_ENABLED)
+    __lsan_do_leak_check();
+#endif
+    signal(signo, SIG_DFL);
+    raise(signo);
 }
 
 int main(int argc, char **argv)

--- a/cfgmgr/nbrmgrd.cpp
+++ b/cfgmgr/nbrmgrd.cpp
@@ -4,12 +4,17 @@
 #include <fstream>
 #include <iostream>
 #include <chrono>
+#include <signal.h>
 
 #include "select.h"
 #include "exec.h"
 #include "schema.h"
 #include "nbrmgr.h"
 #include "warm_restart.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -40,12 +45,29 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("nbrmgrd");
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("--- Starting nbrmgrd ---");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     try
     {

--- a/cfgmgr/portmgrd.cpp
+++ b/cfgmgr/portmgrd.cpp
@@ -3,11 +3,16 @@
 #include <mutex>
 #include <unistd.h>
 #include <vector>
+#include <signal.h>
 
 #include "exec.h"
 #include "portmgr.h"
 #include "schema.h"
 #include "select.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -35,12 +40,29 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("portmgrd");
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("--- Starting portmgrd ---");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     try
     {

--- a/cfgmgr/sflowmgrd.cpp
+++ b/cfgmgr/sflowmgrd.cpp
@@ -3,11 +3,16 @@
 #include <mutex>
 #include <unistd.h>
 #include <vector>
+#include <signal.h>
 
 #include "exec.h"
 #include "sflowmgr.h"
 #include "schema.h"
 #include "select.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -35,12 +40,29 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("sflowmgrd");
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("--- Starting sflowmgrd ---");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     try
     {

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -7,6 +7,10 @@
 #include "warm_restart.h"
 #include <signal.h>
 
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
+
 using namespace std;
 using namespace swss;
 
@@ -26,6 +30,9 @@ bool received_sigterm = false;
 
 void sig_handler(int signo)
 {
+#if defined(ASAN_ENABLED)
+    __lsan_do_leak_check();
+#endif
     received_sigterm = true;
     return;
 }

--- a/cfgmgr/vlanmgrd.cpp
+++ b/cfgmgr/vlanmgrd.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <mutex>
 #include <algorithm>
+#include <signal.h>
 #include "dbconnector.h"
 #include "select.h"
 #include "exec.h"
@@ -14,6 +15,10 @@
 #include "vlanmgr.h"
 #include "shellcmd.h"
 #include "warm_restart.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -43,12 +48,29 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("vlanmgrd");
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("--- Starting vlanmgrd ---");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     try
     {

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -1,6 +1,7 @@
 #include <unistd.h>
 #include <vector>
 #include <mutex>
+#include <signal.h>
 #include "dbconnector.h"
 #include "select.h"
 #include "exec.h"
@@ -9,6 +10,10 @@
 #include <fstream>
 #include <iostream>
 #include "warm_restart.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -36,6 +41,15 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("vrfmgrd");
@@ -43,6 +57,14 @@ int main(int argc, char **argv)
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE("--- Starting vrfmgrd ---");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     try
     {

--- a/cfgmgr/vxlanmgrd.cpp
+++ b/cfgmgr/vxlanmgrd.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <mutex>
 #include <algorithm>
+#include <signal.h>
 #include "dbconnector.h"
 #include "select.h"
 #include "exec.h"
@@ -14,6 +15,10 @@
 #include "vxlanmgr.h"
 #include "shellcmd.h"
 #include "warm_restart.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -42,11 +47,28 @@ string gResponsePublisherRecordFile;
 mutex gDbMutex;
 MacAddress gMacAddress;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("vxlanmgrd");
 
     SWSS_LOG_NOTICE("--- Starting vxlanmgrd ---");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     try
     {

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,26 @@ fi
 AM_CONDITIONAL(GCOV_ENABLED, test x$enable_gcov = xyes)
 AC_MSG_RESULT($enable_gcov)
 
+AC_ARG_ENABLE(asan,
+[  --enable-asan      Compile with address sanitizer],
+[case "${enableval}" in
+	yes) asan_enabled=true ;;
+	no)  asan_enabled=false ;;
+	*) AC_MSG_ERROR(bad value ${enableval} for --enable-asan) ;;
+esac],[asan_enabled=false])
+
+if test "x$asan_enabled" = "xtrue"; then
+    CFLAGS_ASAN+=" -fsanitize=address"
+    CFLAGS_ASAN+=" -DASAN_ENABLED"
+    CFLAGS_ASAN+=" -ggdb -fno-omit-frame-pointer -U_FORTIFY_SOURCE"
+    AC_SUBST(CFLAGS_ASAN)
+
+    LDFLAGS_ASAN+=" -lasan"
+    AC_SUBST(LDFLAGS_ASAN)
+fi
+
+AM_CONDITIONAL(ASAN_ENABLED, test x$asan_enabled = xtrue)
+
 AC_SUBST(CFLAGS_COMMON)
 
 AC_CONFIG_FILES([

--- a/debian/rules
+++ b/debian/rules
@@ -27,10 +27,18 @@ include /usr/share/dpkg/default.mk
 #	dh_auto_configure -- \
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
-ifeq ($(ENABLE_GCOV), y)
-override_dh_auto_configure:
-	dh_auto_configure -- --enable-gcov
+configure_opts =
+ifeq ($(ENABLE_ASAN), y)
+	configure_opts += --enable-asan
 endif
+
+ifeq ($(ENABLE_GCOV), y)
+	configure_opts += --enable-gcov
+endif
+
+override_dh_auto_configure:
+	$(info "override_dh_auto_configure called")
+	dh_auto_configure -- $(configure_opts)
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/swss

--- a/fdbsyncd/Makefile.am
+++ b/fdbsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 fdbsyncd_SOURCES = fdbsyncd.cpp fdbsync.cpp $(top_srcdir)/warmrestart/warmRestartAssist.cpp
 
-fdbsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS)
-fdbsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS)
-fdbsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS)
+fdbsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(CFLAGS_ASAN)
+fdbsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(CFLAGS_ASAN)
+fdbsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS)
 
 if GCOV_ENABLED
 fdbsyncd_LDADD += -lgcovpreload

--- a/fdbsyncd/fdbsyncd.cpp
+++ b/fdbsyncd/fdbsyncd.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <chrono>
+#include <signal.h>
 #include "logger.h"
 #include "select.h"
 #include "netdispatcher.h"
@@ -9,12 +10,33 @@
 #include "fdbsyncd/fdbsync.h"
 #include "warm_restart.h"
 
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
+
 using namespace std;
 using namespace swss;
+
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
 
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("fdbsyncd");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     DBConnector appDb(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     RedisPipeline pipelineAppDB(&appDb);

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrestart/warmRestartHelper.cpp
 
-fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-fpmsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 fpmsyncd_LDADD += -lgcovpreload

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <inttypes.h>
+#include <signal.h>
 #include "logger.h"
 #include "select.h"
 #include "selectabletimer.h"
@@ -8,6 +9,9 @@
 #include "fpmsyncd/fpmlink.h"
 #include "fpmsyncd/routesync.h"
 
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -44,9 +48,27 @@ static bool eoiuFlagsSet(Table &bgpStateTable)
     return true;
 }
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 int main(int argc, char **argv)
 {
     swss::Logger::linkToDbNative("fpmsyncd");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
+
     DBConnector db("APPL_DB", 0);
     RedisPipeline pipeline(&db);
     RouteSync sync(&pipeline);

--- a/gearsyncd/Makefile.am
+++ b/gearsyncd/Makefile.am
@@ -1,6 +1,6 @@
 INCLUDES = -I $(top_srcdir)/lib -I $(top_srcdir) -I $(top_srcdir)/warmrestart -I $(top_srcdir)/cfgmgr
 
-bin_PROGRAMS = gearsyncd 
+bin_PROGRAMS = gearsyncd
 
 if DEBUG
 DBGFLAGS = -ggdb -DDEBUG
@@ -8,11 +8,11 @@ else
 DBGFLAGS = -g
 endif
 
-gearsyncd_SOURCES = $(top_srcdir)/lib/gearboxutils.cpp gearsyncd.cpp gearparserbase.cpp gearboxparser.cpp phyparser.cpp $(top_srcdir)/cfgmgr/shellcmd.h 
+gearsyncd_SOURCES = $(top_srcdir)/lib/gearboxutils.cpp gearsyncd.cpp gearparserbase.cpp gearboxparser.cpp phyparser.cpp $(top_srcdir)/cfgmgr/shellcmd.h
 
-gearsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(ASAN_CFLAGS)
+gearsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(CFLAGS_ASAN)
 
-gearsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS) $(ASAN_LDFLAGS)
+gearsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS)
 
 if GCOV_ENABLED
 gearsyncd_LDADD += -lgcovpreload

--- a/gearsyncd/gearsyncd.cpp
+++ b/gearsyncd/gearsyncd.cpp
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <vector>
 #include <map>
+#include <signal.h>
+
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "warm_restart.h"
@@ -26,6 +28,10 @@
 #include "schema.h"
 
 #include <unistd.h>
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -36,6 +42,15 @@ void usage()
     cout << "       -p gearbox_config.json: import gearbox config" << endl;
     cout << "          use configDB data if not specified" << endl;
 }
+
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
 
 bool handleGearboxConfigFile(string file, bool warm);
 bool handleGearboxConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb, bool warm);
@@ -53,6 +68,15 @@ static void notifyGearboxConfigDone(ProducerStateTable &p, bool success)
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("gearsyncd");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
+
     int opt;
     string gearbox_config_file;
     map<string, KeyOpFieldsValuesTuple> gearbox_cfg_map;

--- a/mclagsyncd/Makefile.am
+++ b/mclagsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 mclagsyncd_SOURCES = mclagsyncd.cpp mclaglink.cpp
 
-mclagsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-mclagsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-mclagsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+mclagsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+mclagsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+mclagsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 mclagsyncd_LDADD += -lgcovpreload

--- a/mclagsyncd/mclagsyncd.cpp
+++ b/mclagsyncd/mclagsyncd.cpp
@@ -18,6 +18,7 @@
  *  Maintainer: Jim Jiang from nephos
  */
 #include <iostream>
+#include <signal.h>
 #include "logger.h"
 #include <map>
 #include "select.h"
@@ -27,12 +28,33 @@
 #include "schema.h"
 #include <set>
 
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
+
 using namespace std;
 using namespace swss;
+
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
 
 int main(int argc, char **argv)
 {
     swss::Logger::linkToDbNative("mclagsyncd");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     DBConnector appl_db("APPL_DB", 0);
     RedisPipeline pipeline(&appl_db);

--- a/natsyncd/Makefile.am
+++ b/natsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 natsyncd_SOURCES = natsyncd.cpp natsync.cpp $(top_srcdir)/warmrestart/warmRestartAssist.cpp
 
-natsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-natsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-natsyncd_LDADD = -lnl-3 -lnl-route-3 -lnl-nf-3 -lswsscommon
+natsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+natsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+natsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lnl-nf-3 -lswsscommon
 
 if GCOV_ENABLED
 natsyncd_LDADD += -lgcovpreload

--- a/natsyncd/natsyncd.cpp
+++ b/natsyncd/natsyncd.cpp
@@ -2,18 +2,40 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <chrono>
+#include <signal.h>
 #include "logger.h"
 #include "select.h"
 #include "netdispatcher.h"
 #include "natsync.h"
 #include <netlink/netfilter/nfnl.h>
 
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
+
 using namespace std;
 using namespace swss;
+
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
 
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("natsyncd");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     DBConnector     appDb("APPL_DB", 0);
     DBConnector     stateDb("STATE_DB", 0);

--- a/neighsyncd/Makefile.am
+++ b/neighsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 neighsyncd_SOURCES = neighsyncd.cpp neighsync.cpp $(top_srcdir)/warmrestart/warmRestartAssist.cpp
 
-neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-neighsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+neighsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 neighsyncd_LDADD += -lgcovpreload

--- a/neighsyncd/neighsyncd.cpp
+++ b/neighsyncd/neighsyncd.cpp
@@ -2,18 +2,40 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <chrono>
+#include <signal.h>
 #include "logger.h"
 #include "select.h"
 #include "netdispatcher.h"
 #include "netlink.h"
 #include "neighsyncd/neighsync.h"
 
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
+
 using namespace std;
 using namespace swss;
+
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
 
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("neighsyncd");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
 
     DBConnector appDb("APPL_DB", 0);
     RedisPipeline pipelineAppDB(&appDb);

--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -109,18 +109,18 @@ orchagent_SOURCES += p4orch/p4orch.cpp \
 		     p4orch/wcmp_manager.cpp \
 		     p4orch/mirror_session_manager.cpp
 
-orchagent_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-orchagent_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-orchagent_LDADD = -lnl-3 -lnl-route-3 -lpthread -lsairedis -lsaimeta -lsaimetadata -lswsscommon -lzmq
+orchagent_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+orchagent_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+orchagent_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lpthread -lsairedis -lsaimeta -lsaimetadata -lswsscommon -lzmq
 
 routeresync_SOURCES = routeresync.cpp
-routeresync_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-routeresync_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-routeresync_LDADD = -lswsscommon
+routeresync_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+routeresync_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+routeresync_LDADD = $(LDFLAGS_ASAN) -lswsscommon
 
 orchagent_restart_check_SOURCES = orchagent_restart_check.cpp
-orchagent_restart_check_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON)
-orchagent_restart_check_LDADD = -lhiredis -lswsscommon -lpthread
+orchagent_restart_check_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+orchagent_restart_check_LDADD = $(LDFLAGS_ASAN) -lhiredis -lswsscommon -lpthread
 
 if GCOV_ENABLED
 orchagent_LDADD += -lgcovpreload

--- a/portsyncd/Makefile.am
+++ b/portsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 portsyncd_SOURCES = $(top_srcdir)/lib/gearboxutils.cpp portsyncd.cpp linksync.cpp  $(top_srcdir)/cfgmgr/shellcmd.h
 
-portsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-portsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+portsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+portsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 portsyncd_LDADD += -lgcovpreload

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <list>
 #include <sys/stat.h>
+#include <signal.h>
 #include "dbconnector.h"
 #include "select.h"
 #include "netdispatcher.h"
@@ -16,6 +17,10 @@
 #include "subscriberstatetable.h"
 #include "exec.h"
 #include "warm_restart.h"
+
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
 
 using namespace std;
 using namespace swss;
@@ -35,6 +40,15 @@ using namespace swss;
 set<string> g_portSet;
 bool g_init = false;
 
+#if defined(ASAN_ENABLED)
+void sigterm_handler(int signo)
+{
+    __lsan_do_leak_check();
+    signal(signo, SIG_DFL);
+    raise(signo);
+}
+#endif
+
 void usage()
 {
     cout << "Usage: portsyncd" << endl;
@@ -51,6 +65,15 @@ void checkPortInitDone(DBConnector *appl_db);
 int main(int argc, char **argv)
 {
     Logger::linkToDbNative("portsyncd");
+
+#if defined(ASAN_ENABLED)
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+#endif
+
     int opt;
     map<string, KeyOpFieldsValuesTuple> port_cfg_map;
 

--- a/swssconfig/Makefile.am
+++ b/swssconfig/Makefile.am
@@ -10,15 +10,15 @@ endif
 
 swssconfig_SOURCES = swssconfig.cpp
 
-swssconfig_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssconfig_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssconfig_LDADD = -lswsscommon
+swssconfig_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+swssconfig_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+swssconfig_LDADD = $(LDFLAGS_ASAN) -lswsscommon
 
 swssplayer_SOURCES = swssplayer.cpp
 
-swssplayer_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssplayer_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssplayer_LDADD = -lswsscommon
+swssplayer_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+swssplayer_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+swssplayer_LDADD = $(LDFLAGS_ASAN) -lswsscommon
 
 if GCOV_ENABLED
 swssconfig_LDADD += -lgcovpreload

--- a/teamsyncd/Makefile.am
+++ b/teamsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 teamsyncd_SOURCES = teamsyncd.cpp teamsync.cpp
 
-teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-teamsyncd_LDADD = -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam
+teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+teamsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam
 
 if GCOV_ENABLED
 teamsyncd_LDADD += -lgcovpreload

--- a/teamsyncd/teamsyncd.cpp
+++ b/teamsyncd/teamsyncd.cpp
@@ -7,6 +7,10 @@
 #include "netlink.h"
 #include "teamsync.h"
 
+#if defined(ASAN_ENABLED)
+#include <sanitizer/lsan_interface.h>
+#endif
+
 using namespace std;
 using namespace swss;
 
@@ -14,6 +18,9 @@ bool received_sigterm = false;
 
 void sig_handler(int signo)
 {
+#if defined(ASAN_ENABLED)
+    __lsan_do_leak_check();
+#endif
     received_sigterm = true;
     return;
 }

--- a/tlm_teamd/Makefile.am
+++ b/tlm_teamd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 tlm_teamd_SOURCES = main.cpp teamdctl_mgr.cpp values_store.cpp
 
-tlm_teamd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-tlm_teamd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(JANSSON_CFLAGS)
-tlm_teamd_LDADD = -lhiredis -lswsscommon -lteamdctl $(JANSSON_LIBS)
+tlm_teamd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+tlm_teamd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(JANSSON_CFLAGS) $(CFLAGS_ASAN)
+tlm_teamd_LDADD = $(LDFLAGS_ASAN) -lhiredis -lswsscommon -lteamdctl $(JANSSON_LIBS)
 
 if GCOV_ENABLED
 tlm_teamd_LDADD += -lgcovpreload


### PR DESCRIPTION
Add SIGTERM handling as a trigger to run a memory leak checker.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
To add a possibility to compile SONiC applications with address sanitizer (ASAN).

> ASAN is a memory error detector for C/C++. It finds:
> - Use after free (dangling pointer dereference)
> - Heap buffer overflow
> - Stack buffer overflow
> - Global buffer overflow
> - Use after return
> - Use after the scope
> - Initialization order bugs
> - Memory leaks

Add SIGTERM handling as a trigger to run a memory leak checker.

**Why I did it**
To add a possibility to detect memory errors in applications.

**How I verified it**
Compile SWSS with **--enable-asan** option. Install applications to DUT. Run tests that trigger different kinds of memory usage inside of applications. Stop applications with **SIGTERM** signal to trigger ASAN report generation. Reports will be placed in **/var/log/asan/** directory.

**Details if related**