### PR TITLE
[asan] Disable the "maybe-uninitialized" warning when compiled with ASAN enabled.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,7 @@ if test "x$asan_enabled" = "xtrue"; then
     CFLAGS_ASAN+=" -fsanitize=address"
     CFLAGS_ASAN+=" -DASAN_ENABLED"
     CFLAGS_ASAN+=" -ggdb -fno-omit-frame-pointer -U_FORTIFY_SOURCE"
+    CFLAGS_ASAN+=" -Wno-maybe-uninitialized"
     AC_SUBST(CFLAGS_ASAN)
 
     LDFLAGS_ASAN+=" -lasan"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix compilation with ASAN enabled for the Debian Bookworm with GCC version 12.2.0 (Debian 12.2.0-14):
```
g++ -DHAVE_CONFIG_H -I. -I.. -I ../lib -I .. -I ../warmrestart -I ../cfgmgr -g  -std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/swss -I/usr/include/libnl3 -Werror -Wno-reorder -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimizatio
n -Wextra -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Winvalid-pch -Wlong-long -Wmissing-field-initializers -Wmissing-format-attribute -Wno-aggregate-return -Wno-padded -Wno-switch-enum -Wno-
unused-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wstack-protector -Wstrict-aliasing=3 -Wswitch -Wswitch-default -Wunreachable-code -Wunused -Wvariadic-macros -Wno-switch-default -Wno-long-long -Wno-redundant-decls -fsanitize=address
-DASAN_ENABLED -ggdb -fno-omit-frame-pointer -U_FORTIFY_SOURCE -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -ffile-prefix-map=/sonic/src/sonic-swss=. -fstack-protector-strong -Wformat -Werror=format-security -c -o portsyncd-asan.o `test -f '../lib/as
an.cpp' || echo './'`../lib/asan.cpp
In file included from /usr/include/c++/12/functional:59,
                 from /usr/include/swss/logger.h:10,
                 from linksync.cpp:7:
In constructor 'std::function<_Res(_ArgTypes ...)>::function(std::function<_Res(_ArgTypes ...)>&&) [with _Res = bool; _ArgTypes = {char}]',
    inlined from 'std::__detail::_State<_Char_type>::_State(std::__detail::_State<_Char_type>&&) [with _Char_type = char]' at /usr/include/c++/12/bits/regex_automaton.h:149:4,
    inlined from 'std::__detail::_State<_Char_type>::_State(std::__detail::_State<_Char_type>&&) [with _Char_type = char]' at /usr/include/c++/12/bits/regex_automaton.h:146:7,
    inlined from 'std::__detail::_StateIdT std::__detail::_NFA<_TraitsT>::_M_insert_subexpr_end() [with _TraitsT = std::__cxx11::regex_traits<char>]' at /usr/include/c++/12/bits/regex_automaton.h:290:24:
/usr/include/c++/12/bits/std_function.h:405:42: error: '*(std::function<bool(char)>*)((char*)&__tmp + offsetof(std::__detail::_StateT, std::__detail::_State<char>::<unnamed>.std::__detail::_State_base::<unnamed>)).std::function<bool(char)>::_M_i
nvoker' may be used uninitialized [-Werror=maybe-uninitialized]
  405 |       : _Function_base(), _M_invoker(__x._M_invoker)
      |                                      ~~~~^~~~~~~~~~
```

**Why I did it**
The compilation fails due to the issue in GGC compiler: [GCC Bugzilla – Bug 105562](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562)
The suggested fix is suppressing the `maybe-uninitialized` warning to overcome the problem and may be removed when the GCC version is upgraded to the one that includes the fix.

**How I verified it**
Compile SWSS package with ASAN enabled.

**Details if related**
